### PR TITLE
Remove delete methods

### DIFF
--- a/src/organizations/examples.http
+++ b/src/organizations/examples.http
@@ -22,9 +22,6 @@ Content-Type:  application/json
 }
 
 ###
-DELETE http://localhost:8080/api/v2/r5/organizations/90b2e19a-415d-4309-b19a-b6a7fa711cdf
-
-###
 PATCH http://localhost:8080/api/v2/r5/organizations/542c4ada-b60a-4b2c-a3d3-51e4ed5079be
 Content-Type:  application/json
 

--- a/src/organizations/organizations.controller.spec.ts
+++ b/src/organizations/organizations.controller.spec.ts
@@ -22,7 +22,6 @@ describe('OrganizationsController', () => {
             findByName: jest.fn(),
             create: jest.fn(),
             update: jest.fn(),
-            remove: jest.fn(),
           },
         },
         { provide: DataStoreService, useValue: testDataStore },
@@ -84,28 +83,6 @@ describe('OrganizationsController', () => {
       const dto = { name: 'test organization' };
       await controller.create(dto);
       expect(service.create).toHaveBeenCalledWith(dto);
-    });
-  });
-
-  describe('remove', () => {
-    it('should call remove method of OrganizationsService', async () => {
-      const mockOrganization: Organization = {
-        id: '1',
-        resourceType: 'Organization',
-      };
-      jest.spyOn(service, 'remove').mockResolvedValue(mockOrganization);
-      const result = await controller.remove('1');
-      expect(result).toEqual(mockOrganization);
-      expect(service.remove).toHaveBeenCalledWith('1');
-    });
-
-    it('should throw an error if organization with id is not found', async () => {
-      jest.spyOn(service, 'remove').mockResolvedValue(undefined);
-
-      await expect(controller.remove('unknown')).rejects.toThrow(
-        NotFoundException,
-      );
-      expect(service.remove).toHaveBeenCalledWith('unknown');
     });
   });
 

--- a/src/organizations/organizations.controller.ts
+++ b/src/organizations/organizations.controller.ts
@@ -1,7 +1,6 @@
 import {
   Body,
   Controller,
-  Delete,
   Get,
   NotFoundException,
   Param,
@@ -69,24 +68,6 @@ export class OrganizationsController {
   @Get(':id')
   async findOne(@Param('id') id: string) {
     const organization = await this.organizationsService.findOne(id);
-
-    if (!organization) {
-      throw new NotFoundException('organization not found');
-    }
-
-    return organization;
-  }
-
-  @ApiOkResponse({
-    description: 'The organization is deleted successfully',
-    type: OrganizationDto,
-  })
-  @ApiNotFoundResponse({
-    description: 'Organization not found',
-  })
-  @Delete(':id')
-  async remove(@Param('id') id: string) {
-    const organization = await this.organizationsService.remove(id);
 
     if (!organization) {
       throw new NotFoundException('organization not found');

--- a/src/organizations/organizations.service.spec.ts
+++ b/src/organizations/organizations.service.spec.ts
@@ -48,28 +48,6 @@ describe('OrganizationsService', () => {
     });
   });
 
-  describe('remove', () => {
-    it("should return undefined for an organization that doesn't exist", async () => {
-      const organization = await service.remove('unknown');
-      expect(organization).toBeUndefined();
-    });
-
-    it('should remove an organization by id', async () => {
-      const organization = await service.remove('1');
-      expect(organization).toBeDefined();
-
-      if (!organization) {
-        throw new Error('Expected organization to be defined in test');
-      }
-
-      expect(organization.id).toBe('1');
-      expect(organization.resourceType).toBe('Organization');
-
-      const allOrganizations = await service.findAll();
-      expect(allOrganizations.length).toBe(2);
-    });
-  });
-
   describe('create', () => {
     it('should create a new organization', async () => {
       const newOrganization = await service.create({

--- a/src/organizations/organizations.service.ts
+++ b/src/organizations/organizations.service.ts
@@ -48,18 +48,6 @@ export class OrganizationsService {
     return undefined;
   }
 
-  async remove(id: string) {
-    const organization = await this.findOne(id);
-
-    if (organization) {
-      this.repo.organizations = this.repo.organizations.filter(
-        (org) => org.id !== id,
-      );
-      return organization;
-    }
-    return undefined;
-  }
-
   async findByName(name: string) {
     return this.repo.organizations.filter(
       (o) => o.name?.toLocaleLowerCase() === name.toLocaleLowerCase(),

--- a/src/practitioners/examples.http
+++ b/src/practitioners/examples.http
@@ -3,6 +3,3 @@ GET http://localhost:8080/api/v2/r5/practitioners
 
 ###
 GET http://localhost:8080/api/v2/r5/practitioners/0535dfde-05f5-4313-911b-cea328127691
-
-###
-DELETE http://localhost:8080/api/v2/r5/practitioners/0535dfde-05f5-4313-911b-cea328127691

--- a/src/practitioners/practitioners.controller.spec.ts
+++ b/src/practitioners/practitioners.controller.spec.ts
@@ -64,27 +64,4 @@ describe('PractitionersController', () => {
       expect(service.findOne).toHaveBeenCalledWith('unknown');
     });
   });
-
-  describe('remove', () => {
-    it('should call remove method of PractitionersService', async () => {
-      const mockPractitioner: Practitioner = {
-        id: '1',
-        resourceType: 'Practitioner',
-      };
-      jest.spyOn(service, 'remove').mockResolvedValue(mockPractitioner);
-
-      const result = await controller.remove('1');
-      expect(result).toEqual(mockPractitioner);
-      expect(service.remove).toHaveBeenCalledWith('1');
-    });
-
-    it('should throw an error if practitioner with id is not found', async () => {
-      jest.spyOn(service, 'remove').mockResolvedValue(undefined);
-
-      await expect(controller.remove('unknown')).rejects.toThrow(
-        NotFoundException,
-      );
-      expect(service.remove).toHaveBeenCalledWith('unknown');
-    });
-  });
 });

--- a/src/practitioners/practitioners.controller.ts
+++ b/src/practitioners/practitioners.controller.ts
@@ -1,10 +1,4 @@
-import {
-  Controller,
-  Delete,
-  Get,
-  NotFoundException,
-  Param,
-} from '@nestjs/common';
+import { Controller, Get, NotFoundException, Param } from '@nestjs/common';
 import { ApiNotFoundResponse, ApiOkResponse } from '@nestjs/swagger';
 import { PractitionerDto } from './dto/practitioner.dto';
 import { PractitionersService } from './practitioners.service';
@@ -33,22 +27,6 @@ export class PractitionersController {
   @Get(':id')
   async findOne(@Param('id') id: string) {
     const practitioner = await this.practitionersService.findOne(id);
-    if (!practitioner) {
-      throw new NotFoundException('practitioner not found');
-    }
-    return practitioner;
-  }
-
-  @ApiOkResponse({
-    description: 'The practitioner is deleted successfully',
-    type: PractitionerDto,
-  })
-  @ApiNotFoundResponse({
-    description: 'Practitioner not found',
-  })
-  @Delete(':id')
-  async remove(@Param('id') id: string) {
-    const practitioner = await this.practitionersService.remove(id);
     if (!practitioner) {
       throw new NotFoundException('practitioner not found');
     }

--- a/src/practitioners/practitioners.service.spec.ts
+++ b/src/practitioners/practitioners.service.spec.ts
@@ -47,25 +47,4 @@ describe('PractitionersService', () => {
       expect(practitioner).toBeUndefined();
     });
   });
-
-  describe('remove', () => {
-    it("should return undefined for an practitioner that doesn't exist", async () => {
-      const practitioner = await service.remove('unknown');
-      expect(practitioner).toBeUndefined();
-    });
-
-    it('should remove an practitioner by id', async () => {
-      const practitioner = await service.remove('1');
-      expect(practitioner).toBeDefined();
-
-      if (!practitioner) {
-        throw new Error('Expected practitioner to be defined in test');
-      }
-      expect(practitioner.id).toBe('1');
-      expect(practitioner.resourceType).toBe('Practitioner');
-
-      const allPractitioners = service.findAll();
-      expect(allPractitioners.length).toBe(1);
-    });
-  });
 });

--- a/src/practitioners/practitioners.service.ts
+++ b/src/practitioners/practitioners.service.ts
@@ -14,16 +14,4 @@ export class PractitionersService {
       (practitioner) => practitioner.id === id,
     );
   }
-
-  async remove(id: string) {
-    const practitioner = await this.findOne(id);
-
-    if (practitioner) {
-      this.repo.practitioners = this.repo.practitioners.filter(
-        (practitioner) => practitioner.id !== id,
-      );
-      return practitioner;
-    }
-    return undefined;
-  }
 }

--- a/test/organizations.e2e-spec.ts
+++ b/test/organizations.e2e-spec.ts
@@ -115,29 +115,6 @@ describe('OrganizationsController (e2e)', () => {
       });
   });
 
-  it('/organizations/:id (DELETE) - OK', async () => {
-    return request(app.getHttpServer())
-      .delete('/organizations/1')
-      .expect(200)
-      .then((res) => {
-        const organization = res.body;
-        expect(organization).toBeDefined();
-        expect(organization).toHaveProperty('id', '1');
-        expect(organization).toHaveProperty('resourceType', 'Organization');
-      });
-  });
-
-  it('/organizations/:id (DELETE) - Not Found', async () => {
-    return request(app.getHttpServer())
-      .delete('/organizations/unknown')
-      .expect(404)
-      .then((res) => {
-        const response = res.body;
-        expect(response).toBeDefined();
-        expect(response).toHaveProperty('message', 'organization not found');
-      });
-  });
-
   it('/organizations/:id (POST) - Created', async () => {
     return request(app.getHttpServer())
       .post('/organizations')


### PR DESCRIPTION
Just removing leads to situations were there are broken references.
e.g. deleting an organization can mean that a `patient.managingOrganization` is broken.