### PR TITLE
chore: update Go version to 1.24.0 and implement structured logging

### DIFF
--- a/apps/resource-statuses/go.mod
+++ b/apps/resource-statuses/go.mod
@@ -1,6 +1,6 @@
 module app
 
-go 1.19
+go 1.24.0
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.12

--- a/apps/resource-statuses/server.go
+++ b/apps/resource-statuses/server.go
@@ -4,14 +4,49 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
+	"os"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/template/html/v2"
 )
 
 const fhirApi = "https://hapi.fhir.org/baseR4/ValueSet"
+
+const appName = "resource-statuses"
+
+var logger *slog.Logger
+
+func init() {
+	opts := &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				return slog.Attr{Key: "timestamp", Value: a.Value}
+			}
+			return a
+		},
+	}
+	h := slog.NewJSONHandler(os.Stdout, opts)
+	logger = slog.New(h).With(slog.String("application", appName))
+}
+
+func requestLogger(l *slog.Logger) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		start := time.Now()
+		err := c.Next()
+		l.Info("request",
+			slog.String("method", c.Method()),
+			slog.String("path", c.Path()),
+			slog.Int("status", c.Response().StatusCode()),
+			slog.String("ip", c.IP()),
+			slog.Duration("latency", time.Since(start)),
+		)
+		return err
+	}
+}
 
 // ValueSet represents a FHIR R5 ValueSet resource
 type ValueSet struct {
@@ -34,80 +69,75 @@ type ExpandedConcept struct {
 
 type ExpandedConcepts []ExpandedConcept
 
-func GetStatuses(valueSet string) ExpandedConcepts {
-	resp, err := http.Get(fhirApi + "/$expand?url=http://hl7.org/fhir/ValueSet/" + valueSet)
-
+func GetStatuses(valueSet string) (ExpandedConcepts, error) {
+	url := fmt.Sprintf("%s/$expand?url=http://hl7.org/fhir/ValueSet/%s", fhirApi, valueSet)
+	resp, err := http.Get(url)
 	if err != nil {
-		log.Fatalln(err)
+		return nil, fmt.Errorf("http get: %w", err)
 	}
-
 	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
 
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalln(err)
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var result ValueSet
 	if err := json.Unmarshal(body, &result); err != nil {
-		fmt.Println("Can not unmarshal JSON")
+		return nil, fmt.Errorf("unmarshal: %w", err)
 	}
 
-	return result.Expansion.Contains
+	return result.Expansion.Contains, nil
+}
+
+func renderResourceStatuses(c *fiber.Ctx, valueSet string, resourceType string) error {
+	values, err := GetStatuses(valueSet)
+	if err != nil {
+		logger.Error("get statuses failed", slog.String("valueSet", valueSet), slog.Any("err", err))
+		return fiber.ErrInternalServerError
+	}
+	return c.Render("resource-statuses", fiber.Map{
+		"ResourceType": resourceType,
+		"Results":      values,
+	})
 }
 
 func main() {
 	engine := html.New("./views", ".html")
 	app := fiber.New(fiber.Config{Views: engine})
 
+	app.Use(requestLogger(logger))
+
 	app.Get("/", func(c *fiber.Ctx) error {
 		return c.Render("index", fiber.Map{})
 	})
 
 	app.Get("/encounter", func(c *fiber.Ctx) error {
-		values := GetStatuses("encounter-status")
-
-		return c.Render("resource-statuses", fiber.Map{
-			"ResourceType": "Encounter",
-			"Results":      values,
-		})
+		return renderResourceStatuses(c, "encounter-status", "Encounter")
 	})
 
 	app.Get("/observation", func(c *fiber.Ctx) error {
-		values := GetStatuses("observation-status")
-
-		return c.Render("resource-statuses", fiber.Map{
-			"ResourceType": "Observation",
-			"Results":      values,
-		})
+		return renderResourceStatuses(c, "observation-status", "Observation")
 	})
 
 	app.Get("/episode-of-care", func(c *fiber.Ctx) error {
-		values := GetStatuses("episode-of-care-status")
-
-		return c.Render("resource-statuses", fiber.Map{
-			"ResourceType": "Episode of Care",
-			"Results":      values,
-		})
+		return renderResourceStatuses(c, "episode-of-care-status", "Episode of Care")
 	})
 
 	app.Get("/appointment", func(c *fiber.Ctx) error {
-		values := GetStatuses("appointmentstatus")
-
-		return c.Render("resource-statuses", fiber.Map{
-			"ResourceType": "Appointment",
-			"Results":      values,
-		})
+		return renderResourceStatuses(c, "appointmentstatus", "Appointment")
 	})
 
 	app.Get("/flag", func(c *fiber.Ctx) error {
-		values := GetStatuses("flag-status")
-
-		return c.Render("resource-statuses", fiber.Map{
-			"ResourceType": "Flag",
-			"Results":      values,
-		})
+		return renderResourceStatuses(c, "flag-status", "Flag")
 	})
 
-	app.Listen(":3000")
+	logger.Info("server listening", slog.String("addr", ":3000"))
+	if err := app.Listen(":3000"); err != nil {
+		logger.Error("server failed", slog.Any("err", err))
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
- Updated Go version in go.mod from 1.19 to 1.24.0.
- Replaced standard log package with slog for structured logging.
- Added request logging middleware to capture request details.
- Refactored GetStatuses function to return errors instead of logging fatals.
- Enhanced error handling in the application.